### PR TITLE
# [Feature] - Refactor resolver-data service, is-admin resolver and create isAdmin() function.

### DIFF
--- a/src/app/pages/dashboard.component.ts
+++ b/src/app/pages/dashboard.component.ts
@@ -1,23 +1,20 @@
-import {Component, inject} from "@angular/core";
-import {ActivatedRoute, RouterOutlet} from "@angular/router";
+import {Component} from "@angular/core";
 import {AsyncPipe, NgIf} from "@angular/common";
-import {ResolverDataService} from "../services/resolver-data.service";
+import {isAdmin} from "../shared/functions/is-admin";
 
 @Component({
   selector: 'dashboard',
   template: `
     <div>Dashboard</div>
-    <div *ngIf="isAdmin$ | async">Welcome Back MAU</div>
+    <div *ngIf="isAdmin$ | async">Welcome Back you are admin</div>
     <div *ngIf="!(isAdmin$ | async)">You are NOT admin</div>
   `,
   standalone: true,
   imports: [
-    RouterOutlet,
     NgIf,
     AsyncPipe
   ]
 })
 export class DashboardComponent {
-  private readonly route = inject(ActivatedRoute);
-  isAdmin$ = inject(ResolverDataService).isAdmin$;
+  isAdmin$ = isAdmin();
 }

--- a/src/app/services/resolver-data.service.ts
+++ b/src/app/services/resolver-data.service.ts
@@ -3,10 +3,9 @@ import {BehaviorSubject} from "rxjs";
 
 @Injectable({providedIn: 'root'})
 export class ResolverDataService {
-  private isAdmin = new BehaviorSubject<boolean>(false);
-  isAdmin$ = this.isAdmin.asObservable();
+  isAdmin$ = new BehaviorSubject<boolean>(false);
 
-  setAdmin(isAdmin: boolean) {
-    this.isAdmin.next(isAdmin)
+  setAdminPermission(isAdmin: boolean) {
+    this.isAdmin$.next(isAdmin)
   }
 }

--- a/src/app/shared/components/toolbar.component.ts
+++ b/src/app/shared/components/toolbar.component.ts
@@ -6,7 +6,7 @@ import {MatIconButton} from "@angular/material/button";
 import {MatToolbar, MatToolbarRow} from "@angular/material/toolbar";
 import {MatMenu, MatMenuItem, MatMenuModule} from "@angular/material/menu";
 import {AsyncPipe, NgIf} from "@angular/common";
-import {ResolverDataService} from "../../services/resolver-data.service";
+import {isAdmin} from "../functions/is-admin";
 
 @Component({
   selector: 'toolbar',
@@ -71,7 +71,7 @@ import {ResolverDataService} from "../../services/resolver-data.service";
 })
 export class ToolbarComponent {
   private readonly authService = inject(AuthService);
-  isAdmin$ = inject(ResolverDataService).isAdmin$;
+  readonly isAdmin$ = isAdmin();
   router = inject(Router);
 
   logout() {

--- a/src/app/shared/functions/is-admin.ts
+++ b/src/app/shared/functions/is-admin.ts
@@ -1,0 +1,7 @@
+import {ResolverDataService} from "../../services/resolver-data.service";
+import {inject} from "@angular/core";
+
+export const isAdmin = () => {
+  const resolverService = inject(ResolverDataService)
+  return resolverService.isAdmin$.asObservable();
+}

--- a/src/app/shared/resolvers/is-admin.resolver.ts
+++ b/src/app/shared/resolvers/is-admin.resolver.ts
@@ -6,15 +6,16 @@ import {ResolverDataService} from "../../services/resolver-data.service";
 export const adminRoleResolver = () => {
   const adminService = inject(AdminService);
   const resolveDataService = inject(ResolverDataService)
+
   return adminService.validateAdmin().pipe(
     map(res => {
       const isAdmin = res.status === 'success';
-      resolveDataService.setAdmin(isAdmin);
-      return isAdmin;
+      resolveDataService.setAdminPermission(isAdmin);
     }),
     catchError(() => {
-      resolveDataService.setAdmin(false)
+      resolveDataService.setAdminPermission(false)
       return of(false)
     })
   );
+
 };


### PR DESCRIPTION

## Description
The primary objective of this PR was the refactor of the resolver-data.service.ts and the creation of is-admin() function.

### Problem:
- ResolverDataService is being injected in the controllers every time we need to know if the user is admin or not.
- ResolverDataService sets the behaviourSubject isAdmin$ value and also export it as an Observable().
- isAdmin && isAdmin$ nomenclature is propitious to difficult code reading.

### Solution:
- The solution to this problem was the creation of isAdmin() function.
- This function can be imported when we need to check if the logged user isAdmin or not.

### Summary of Changes:
- Refactor isAdmin$ behaviourSubject on resolver-data.service
- Create isAdmin() function.
- Code clean up.

### Files Added:
*functions/is-admin.ts*

### Next Steps:
-  Create a users list page and get all the registered users.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement - code clean up,
- [ ] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.